### PR TITLE
Fix latent array handling for sampler

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -75,8 +75,13 @@ class MLXSampler:
         num_steps = steps 
         cfg_weight = cfg
             
-        batch, channels, height, width = latent_image["samples"].shape
-        
+        if isinstance(latent_image, dict) and "samples" in latent_image:
+            latent = latent_image["samples"]
+        else:
+            latent = latent_image
+
+        batch, channels, height, width = latent.shape
+
         latent_size = (height, width)
         
         latents, iter_time  = mlx_model.denoise_latents(


### PR DESCRIPTION
## Summary
- robustly handle latent inputs in `MLXSampler.generate_image`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'argmaxtools')*

------
https://chatgpt.com/codex/tasks/task_e_68567cb0c1988322a2122ff551a7e532